### PR TITLE
hub default url to /lab

### DIFF
--- a/hub/values.yaml
+++ b/hub/values.yaml
@@ -27,8 +27,8 @@ jupyterhub:
     defaultUrl: "/lab"
   hub:
     extraConfig:
-      jupyterlab: |
-        c.Spawner.cmd = ['jupyter-labhub']
+      00-jupyterlab: |
+        c.Spawner.default_url = '/lab'
       01-hub-config: |
         c.JupyterHub.shutdown_on_logout = True
 


### PR DESCRIPTION
just ran into this trying new image on the staging hub:

```
➜  jupyter-image-2020 git:(master) kubectl logs -n hackweek-hub-staging   jupyter-scottyhq  
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/jupyter-labhub", line 6, in <module>
    from jupyterlab.labhubapp import main
ModuleNotFoundError: No module named 'jupyterlab.labhubapp'
```

fix described in this issue https://github.com/jupyter/docker-stacks/issues/1041