### PR TITLE
slight change to resource requests, explicit image pins

### DIFF
--- a/deployments/hackweek-hub/config/common.yaml
+++ b/deployments/hackweek-hub/config/common.yaml
@@ -14,7 +14,7 @@ jupyterhub:
     startTimeout: 600
     cpu:
       limit: 4
-      guarantee: 2
+      guarantee: 1.75
     memory:
       limit: 8G
       guarantee: 7G

--- a/deployments/hackweek-hub/config/prod.yaml
+++ b/deployments/hackweek-hub/config/prod.yaml
@@ -11,7 +11,7 @@ jupyterhub:
       - display_name: "IceSat-2 Hackweek 2020 Image"
         default: true
         kubespawner_override:
-          image: uwhackweeks/icesat2:latest
+          image: uwhackweeks/icesat2:2020.06.03
     initContainers:
       - name: volume-mount-hack
         image: busybox

--- a/deployments/hackweek-hub/config/staging.yaml
+++ b/deployments/hackweek-hub/config/staging.yaml
@@ -15,7 +15,7 @@ jupyterhub:
       - display_name: "IceSat-2 Hackweek 2020 Image"
         default: true
         kubespawner_override:
-          image: uwhackweeks/icesat2:master
+          image: uwhackweeks/icesat2:0da55cd
     initContainers:
       - name: volume-mount-hack
         image: busybox


### PR DESCRIPTION
This will pack 4 users per node. 

Also pins to specific tags, otherwise if nodes keep running and new images are pushed with 'latest' or 'master' tags they are not pulled. the 'latest' and 'master' was convenient for testing since most days nodes scaled to zero... this might not happen over the next few weeks