### PR TITLE
force cull user pods after 12 hours

### DIFF
--- a/deployments/hackweek-hub/config/common.yaml
+++ b/deployments/hackweek-hub/config/common.yaml
@@ -18,6 +18,9 @@ jupyterhub:
     memory:
       limit: 8G
       guarantee: 7G
+  # automatically terminate pods after 12 hours 
+  cull:
+    maxAge: 43200
   auth:
     type: github
     github:


### PR DESCRIPTION
cc @salvis2 

Adds `maxAge` of user pods
https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/7d2d3eb1c8e04853bfc775bbd1d895769be04b09/jupyterhub/values.yaml#L376 

During the hackweek it became clear that we can't rely on people to always log out of their notebook server at the end of the day. This leads to nodes running for several days, but we want to scale to zero overnight when people aren't working.

```
NAME                        READY   STATUS    RESTARTS   AGE
autohttps-fb46dd8fc-fkq7b   2/2     Running   0          30d
hub-8645d8b59-pfdvq         1/1     Running   0          4d11h
jupyter-user1                         1/1     Running   0          16h
jupyter-user2                       1/1     Running   0          65m
jupyter-user3                     1/1     Running   0          2d
jupyter-user4                  1/1     Running   0          69m
jupyter-user5               1/1     Running   0          179m
jupyter-user6              1/1     Running   0          24h
jupyter-user7            1/1     Running   0          30h
```

Marking a node to drain (`kubectl drain [node]`) doesn't solve the issue because user pods can't be moved while running to new nodes. This is a heavy-handed fix to force shutdown of a server running for more than 12 hours.

